### PR TITLE
Add option to output screenshot to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 | monitor | Take screenshot from only a monitor |
 | save | Save the output to a image file |
 | clipboard | Copy the output to the clipboard |
+| output | Outputs screenshot to stdout encoded as png  |
 
 &nbsp;
 ### Example
@@ -23,6 +24,10 @@ goshot -f -S 'image.png'
 #### Selected area and copy to clipboard
 ```bash
 goshot -s -c
+```
+#### Fullscreen and output to stdout
+```bash
+goshot -f -o
 ```
 
 <br><br>

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,15 +14,16 @@ var rootCmd = cobra.Command {
         monitor, _ := c.Flags().GetInt("monitor")
         clipboard, _ := c.Flags().GetBool("clipboard")
         save, _ := c.Flags().GetString("save")
+        output, _ := c.Flags().GetBool("output")
 
         if fullscreen {
-           modes.Fullscreen(save, clipboard)
+           modes.Fullscreen(save, clipboard, output)
 
         } else if selection {
-            modes.Selection(save, clipboard)
+            modes.Selection(save, clipboard, output)
 
         } else if monitor != -1 {
-            modes.Monitor(save, clipboard, monitor)
+            modes.Monitor(save, clipboard, monitor, output)
 
         } else {
             c.Help()
@@ -37,6 +38,7 @@ func init() {
     rootCmd.PersistentFlags().BoolP("clipboard", "c", false, "Save output to clipboard")
     rootCmd.PersistentFlags().IntP("monitor", "m", -1, "Monitor mode")
     rootCmd.PersistentFlags().StringP("save", "S", "", "Save output to file")
+    rootCmd.PersistentFlags().BoolP("output", "o", false, "Outputs screenshot to stdout")
 }
 
 func Execute() {

--- a/modes/fullscreen.go
+++ b/modes/fullscreen.go
@@ -5,7 +5,7 @@ import (
     "github.com/z3oxs/goshot/utils"
 )
 
-func Fullscreen(save string, clipboard bool) {
+func Fullscreen(save string, clipboard, output bool) {
     screenshot := robotgo.CaptureImg()
 
     if clipboard {
@@ -17,6 +17,10 @@ func Fullscreen(save string, clipboard bool) {
     } else {
         utils.SaveToClipboard(screenshot)
 
+    }
+
+    if output {
+        utils.OutputToStdout(screenshot)
     }
     
     utils.PlaySound("/opt/goshot/screenshot.wav")

--- a/modes/monitor.go
+++ b/modes/monitor.go
@@ -8,7 +8,7 @@ import (
     "github.com/go-vgo/robotgo"
 )
 
-func Monitor(save string, clipboard bool, monitor int) {
+func Monitor(save string, clipboard bool, monitor int, output bool) {
     var screenshot image.Image
 
     monitors := utils.GetDisplays()
@@ -36,6 +36,10 @@ func Monitor(save string, clipboard bool, monitor int) {
     } else {
         utils.SaveToClipboard(screenshot)
 
+    }
+
+    if output {
+        utils.OutputToStdout(screenshot)
     }
     
     utils.PlaySound("/opt/goshot/screenshot.wav")

--- a/modes/selection.go
+++ b/modes/selection.go
@@ -5,10 +5,11 @@ import (
     "log"
 
     "github.com/z3oxs/goshot/utils"
+
     "github.com/go-vgo/robotgo"
 )
 
-func Selection(save string, clipboard bool) {
+func Selection(save string, clipboard, output bool) {
     var x1, x2, y1, y2 int
     var screenshot image.Image
 
@@ -46,6 +47,10 @@ func Selection(save string, clipboard bool) {
     } else {
         utils.SaveToClipboard(screenshot)
 
+    }
+
+    if output {
+        utils.OutputToStdout(screenshot)
     }
 
     utils.PlaySound("/opt/goshot/screenshot.wav")

--- a/utils/outputToStdout.go
+++ b/utils/outputToStdout.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+    "image"
+    "image/png"
+    "log"
+    "os"
+)
+
+func OutputToStdout(image image.Image) {
+    err := png.Encode(os.Stdout, image)
+
+    if err != nil {
+        log.Fatal(err)
+    }
+}


### PR DESCRIPTION
Allows for command chaining when used in external scripts, without having to resort to temporary files.